### PR TITLE
Incorrectbillnumerrormsg

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ When creating a new Legislature Tracker object, you can set the following option
 * ```state```: The two character state code as used by Open States.
 * ```session```: The session key as used on Open States, like ```2013-2014```.
 * ```OSKey```: Your Open States API Key.
-* ```eKey```: Your Google Spreadsheet identifier.
+* ```eKey```: Your Google Spreadsheet identifier. Be sure to publish your spreadsheet (File -> Publish to the web) to make it available via the Google Spreadsheet API.
 * ```imagePath```:  'https://s3.amazonaws.com/data.minnpost/projects/legislature-tracker/images/',
 * ```legImageProxy```: If you want to proxy images from Open States, but in the URL prefix, like ```http://proxy.com/?url=```.  For instance we [this custom proxy](https://github.com/MinnPost/i-mage-proxerific).
 * ```aggregateURL```: An API JSON feed to get some aggregate bill counts.  This is specific to MinnPost (MN).
@@ -41,6 +41,8 @@ First make sure you have 3 sheets with the following columns:
     * ```title```
     * ```short_title```: Used for the top menu list.
     * ```description```
+    * ```open_states_subjects```
+    * ```legislator_subjects```
     * ```links```: Links field, see below.
     * ```image```: Name of image for the category.  These currently live in the images directory.
 * ```Bills```

--- a/js/app/core.js
+++ b/js/app/core.js
@@ -265,4 +265,10 @@ else {
     tabletopOptions: {}
   };
   
+  LT.log = function(text){
+    if (!_.isUndefined(window.console)){
+      window.console.log(text);
+    }
+  }
+  
 })(jQuery, window);

--- a/js/app/models.js
+++ b/js/app/models.js
@@ -196,7 +196,7 @@
         }
         this.set('last_updated_at', last_updated_at);
       }else if(_.isUndefined(this.get('last_updated_at')) && !p.get('updated_at')){
-        console.log("Couldn't fetch primary bill data from OpenStates. Is its bill number " + this.get('bill_primary').get("bill_id") + " formatted properly?");
+        LT.log("Couldn't fetch primary bill data from OpenStates. Is its bill number " + this.get('bill_primary').get("bill_id") + " formatted properly?");
       }
       
       return this.get('last_updated_at');

--- a/js/app/models.js
+++ b/js/app/models.js
@@ -195,6 +195,8 @@
             co.get('updated_at') : last_updated_at;
         }
         this.set('last_updated_at', last_updated_at);
+      }else if(_.isUndefined(this.get('last_updated_at')) && !p.get('updated_at')){
+        console.log("Couldn't fetch primary bill data from OpenStates. Is its bill number " + this.get('bill_primary').get("bill_id") + " formatted properly?");
       }
       
       return this.get('last_updated_at');


### PR DESCRIPTION
to fix #13.

Console.log a more helpful msg when the updated_time can't be gotten from OpenStates, most likely because the bill number is incorrectly formatted (see #13) for examples.
